### PR TITLE
Il nome progetto è ora impostato una sola volta

### DIFF
--- a/scripts/Grunt.config.build.js
+++ b/scripts/Grunt.config.build.js
@@ -84,7 +84,7 @@ module.exports = {
 			dest: '<%= buildDir %>/templates.js',
 			options: {
 				bootstrap: function(module, script) {
-					return 'var initTemplates = function(){ angular.module("modular-angular-seed").run(["$templateCache", function($templateCache) {' + script + ' }]);};';
+					return 'var initTemplates = function(){ angular.module("' + grunt.option('projectName') + '").run(["$templateCache", function($templateCache) {' + script + ' }]);};';
 				},
 				htmlmin: {
 					collapseBooleanAttributes: true,

--- a/scripts/Gruntfile.js
+++ b/scripts/Gruntfile.js
@@ -7,6 +7,8 @@ module.exports = function(grunt) {
 		buildDir: "../bin"
 	};
 
+	grunt.option('projectName',config.pkg.name);
+
 	config = _.merge(config, require("./Grunt.config.install.js"));
 	config = _.merge(config, require("./Grunt.config.serve.js"));
 	config = _.merge(config, require("./Grunt.config.style.js"));

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "angular-modular-seed",
+  "name": "modular-angular-seed",
   "version": "0.0.1",
   "description": "Angular Modular Seed",
   "main": "index.html",


### PR DESCRIPTION
Il nome progetto è ora impostato una sola volta. Inoltre ho corretto in nome del progetto sul package.json. Per ottenere questo risultato ho impostato una option su grunt.option. Non so se esiste un modo più elegante ma sembra funzionare ;)
